### PR TITLE
fix allowprelease error

### DIFF
--- a/PowerShellGet/public/Publish-Module.ps1
+++ b/PowerShellGet/public/Publish-Module.ps1
@@ -200,8 +200,7 @@ function Publish-Module
             {
                 $ValidationResult = Validate-VersionParameters -CallerPSCmdlet $PSCmdlet `
                                                                -Name $Name `
-                                                               -RequiredVersion $RequiredVersion `
-                                                               -AllowPrerelease:$AllowPrerelease
+                                                               -RequiredVersion $RequiredVersion
                 if(-not $ValidationResult)
                 {
                     # Validate-VersionParameters throws the error.


### PR DESCRIPTION
In the publish-module.ps1 script file, I removed the line "-AllowPrerelease:$AllowPrerelease" line from the Validate-versionparameters.  I did this due to the fact that, when attempting to publish a powershell module to a vsts package feed with the line present, it would throw an error stating "AllowPrereleaseVersions is not a valid parameter."  When I commented out that one line, saved the changed to the module, re-imported it, and re-ran the command, the module published successfully.