### PR TITLE
 fix New-scriptfileinfo command

### DIFF
--- a/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
+++ b/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
@@ -50,7 +50,7 @@ function Get-ScriptCommentHelpInfoString {
 
     Process {
         If ($newscriptnfo) {
-            $ScriptCommentHelpInfoString = "`r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
+            $ScriptCommentHelpInfoString = ".DESCRIPTION `r`n $Description `r`n`r`n"
         }
         else {
             $ScriptCommentHelpInfoString = "<# `r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
@@ -108,13 +108,7 @@ function Get-ScriptCommentHelpInfoString {
             $ScriptCommentHelpInfoString += ".FUNCTIONALITY `r`n$($Functionality -join "`r`n") `r`n`r`n"
         }
 
-        If ($newscriptnfo) {
-            $ScriptCommentHelpInfoString += "`r`n"
-        }
-        else {
-            $ScriptCommentHelpInfoString += "#> `r`n"
-        }
-
+        $ScriptCommentHelpInfoString += "#> `r`n"
         return $ScriptCommentHelpInfoString
     }
 }

--- a/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
+++ b/src/PowerShellGet/private/functions/Get-ScriptCommentHelpInfoString.ps1
@@ -1,9 +1,8 @@
-function Get-ScriptCommentHelpInfoString
-{
-    [CmdletBinding(PositionalBinding=$false)]
+function Get-ScriptCommentHelpInfoString {
+    [CmdletBinding(PositionalBinding = $false)]
     Param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Description,
@@ -42,79 +41,79 @@ function Get-ScriptCommentHelpInfoString
 
         [Parameter()]
         [string]
-        $Functionality
+        $Functionality,
+
+        [Parameter()]
+        [Switch]
+        $newscriptnfo
     )
 
-    Process
-    {
-        $ScriptCommentHelpInfoString = "<# `r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
+    Process {
+        If ($newscriptnfo) {
+            $ScriptCommentHelpInfoString = "`r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
+        }
+        else {
+            $ScriptCommentHelpInfoString = "<# `r`n`r`n.DESCRIPTION `r`n $Description `r`n`r`n"
+        }
 
-        if("$Synopsis".Trim())
-        {
+        if ("$Synopsis".Trim()) {
             $ScriptCommentHelpInfoString += ".SYNOPSIS `r`n$Synopsis `r`n`r`n"
         }
 
-        if("$Example".Trim())
-        {
+        if ("$Example".Trim()) {
             $Example | ForEach-Object {
-                           if($_)
-                           {
-                               $ScriptCommentHelpInfoString += ".EXAMPLE `r`n$_ `r`n`r`n"
-                           }
-                       }
+                if ($_) {
+                    $ScriptCommentHelpInfoString += ".EXAMPLE `r`n$_ `r`n`r`n"
+                }
+            }
         }
 
-        if("$Inputs".Trim())
-        {
+        if ("$Inputs".Trim()) {
             $Inputs |  ForEach-Object {
-                           if($_)
-                           {
-                               $ScriptCommentHelpInfoString += ".INPUTS `r`n$_ `r`n`r`n"
-                           }
-                       }
+                if ($_) {
+                    $ScriptCommentHelpInfoString += ".INPUTS `r`n$_ `r`n`r`n"
+                }
+            }
         }
 
-        if("$Outputs".Trim())
-        {
+        if ("$Outputs".Trim()) {
             $Outputs |  ForEach-Object {
-                           if($_)
-                           {
-                               $ScriptCommentHelpInfoString += ".OUTPUTS `r`n$_ `r`n`r`n"
-                           }
-                       }
+                if ($_) {
+                    $ScriptCommentHelpInfoString += ".OUTPUTS `r`n$_ `r`n`r`n"
+                }
+            }
         }
 
-        if("$Notes".Trim())
-        {
+        if ("$Notes".Trim()) {
             $ScriptCommentHelpInfoString += ".NOTES `r`n$($Notes -join "`r`n") `r`n`r`n"
         }
 
-        if("$Link".Trim())
-        {
+        if ("$Link".Trim()) {
             $Link |  ForEach-Object {
-                         if($_)
-                         {
-                              $ScriptCommentHelpInfoString += ".LINK `r`n$_ `r`n`r`n"
-                         }
-                     }
+                if ($_) {
+                    $ScriptCommentHelpInfoString += ".LINK `r`n$_ `r`n`r`n"
+                }
+            }
         }
 
-        if("$Component".Trim())
-        {
+        if ("$Component".Trim()) {
             $ScriptCommentHelpInfoString += ".COMPONENT `r`n$($Component -join "`r`n") `r`n`r`n"
         }
 
-        if("$Role".Trim())
-        {
+        if ("$Role".Trim()) {
             $ScriptCommentHelpInfoString += ".ROLE `r`n$($Role -join "`r`n") `r`n`r`n"
         }
 
-        if("$Functionality".Trim())
-        {
+        if ("$Functionality".Trim()) {
             $ScriptCommentHelpInfoString += ".FUNCTIONALITY `r`n$($Functionality -join "`r`n") `r`n`r`n"
         }
 
-        $ScriptCommentHelpInfoString += "#> `r`n"
+        If ($newscriptnfo) {
+            $ScriptCommentHelpInfoString += "`r`n"
+        }
+        else {
+            $ScriptCommentHelpInfoString += "#> `r`n"
+        }
 
         return $ScriptCommentHelpInfoString
     }

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -1,16 +1,15 @@
-function New-ScriptFileInfo
-{
+function New-ScriptFileInfo {
     <#
     .ExternalHelp PSModule-help.xml
     #>
-    [CmdletBinding(PositionalBinding=$false,
-                   SupportsShouldProcess=$true,
-                   HelpUri='https://go.microsoft.com/fwlink/?LinkId=619792')]
+    [CmdletBinding(PositionalBinding = $false,
+        SupportsShouldProcess = $true,
+        HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619792')]
     Param
     (
-        [Parameter(Mandatory=$false,
-                   Position=0,
-                   ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory = $false,
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
@@ -25,7 +24,7 @@ function New-ScriptFileInfo
         [string]
         $Author,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Description,
@@ -89,8 +88,8 @@ function New-ScriptFileInfo
         [string[]]
         $ReleaseNotes,
 
-		[Parameter()]
-		[ValidateNotNullOrEmpty()]
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [string]
         $PrivateData,
 
@@ -103,100 +102,86 @@ function New-ScriptFileInfo
         $Force
     )
 
-    Process
-    {
-        if($Path)
-        {
-            if(-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase))
-            {
+    Process {
+        if ($Path) {
+            if (-not $Path.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase)) {
                 $errorMessage = ($LocalizedData.InvalidScriptFilePath -f $Path)
                 ThrowError  -ExceptionName 'System.ArgumentException' `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId 'InvalidScriptFilePath' `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $Path `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId 'InvalidScriptFilePath' `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $Path `
+                    -ErrorCategory InvalidArgument
                 return
             }
 
-            if(-not $Force -and (Microsoft.PowerShell.Management\Test-Path -Path $Path))
-            {
+            if (-not $Force -and (Microsoft.PowerShell.Management\Test-Path -Path $Path)) {
                 $errorMessage = ($LocalizedData.ScriptFileExist -f $Path)
                 ThrowError  -ExceptionName 'System.ArgumentException' `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId 'ScriptFileExist' `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $Path `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId 'ScriptFileExist' `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $Path `
+                    -ErrorCategory InvalidArgument
                 return
             }
         }
-        elseif(-not $PassThru)
-        {
+        elseif (-not $PassThru) {
             ThrowError  -ExceptionName 'System.ArgumentException' `
-                        -ExceptionMessage $LocalizedData.MissingTheRequiredPathOrPassThruParameter `
-                        -ErrorId 'MissingTheRequiredPathOrPassThruParameter' `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ErrorCategory InvalidArgument
+                -ExceptionMessage $LocalizedData.MissingTheRequiredPathOrPassThruParameter `
+                -ErrorId 'MissingTheRequiredPathOrPassThruParameter' `
+                -CallerPSCmdlet $PSCmdlet `
+                -ErrorCategory InvalidArgument
             return
         }
 
-        if(-not $Version)
-        {
+        if (-not $Version) {
             $Version = '1.0'
         }
-        else
-        {
+        else {
             $result = ValidateAndGet-VersionPrereleaseStrings -Version $Version -CallerPSCmdlet $PSCmdlet
-            if (-not $result)
-            {
+            if (-not $result) {
                 # ValidateAndGet-VersionPrereleaseStrings throws the error.
                 # returning to avoid further execution when different values are specified for -ErrorAction parameter
                 return
             }
         }
 
-        if(-not $Author)
-        {
-            if($script:IsWindows)
-            {
+        if (-not $Author) {
+            if ($script:IsWindows) {
                 $Author = (Get-EnvironmentVariable -Name 'USERNAME' -Target $script:EnvironmentVariableTarget.Process -ErrorAction SilentlyContinue)
             }
-            else
-            {
+            else {
                 $Author = $env:USER
             }
         }
 
-        if(-not $Guid)
-        {
+        if (-not $Guid) {
             $Guid = [System.Guid]::NewGuid()
         }
 
         $params = @{
-            Version = $Version
-            Author = $Author
-            Guid = $Guid
-            CompanyName = $CompanyName
-            Copyright = $Copyright
+            Version                    = $Version
+            Author                     = $Author
+            Guid                       = $Guid
+            CompanyName                = $CompanyName
+            Copyright                  = $Copyright
             ExternalModuleDependencies = $ExternalModuleDependencies
-            RequiredScripts = $RequiredScripts
+            RequiredScripts            = $RequiredScripts
             ExternalScriptDependencies = $ExternalScriptDependencies
-            Tags = $Tags
-            ProjectUri = $ProjectUri
-            LicenseUri = $LicenseUri
-            IconUri = $IconUri
-            ReleaseNotes = $ReleaseNotes
-			PrivateData = $PrivateData
+            Tags                       = $Tags
+            ProjectUri                 = $ProjectUri
+            LicenseUri                 = $LicenseUri
+            IconUri                    = $IconUri
+            ReleaseNotes               = $ReleaseNotes
+            PrivateData                = $PrivateData
         }
 
-        if(-not (Validate-ScriptFileInfoParameters -parameters $params))
-        {
+        if (-not (Validate-ScriptFileInfoParameters -parameters $params)) {
             return
         }
 
-        if("$Description" -match '<#' -or "$Description" -match '#>')
-        {
+        if ("$Description" -match '<#' -or "$Description" -match '#>') {
             $message = $LocalizedData.InvalidParameterValue -f ($Description, 'Description')
             Write-Error -Message $message -ErrorId 'InvalidParameterValue' -Category InvalidArgument
 
@@ -207,13 +192,12 @@ function New-ScriptFileInfo
 
         $requiresStrings = Get-RequiresString -RequiredModules $RequiredModules
 
-        $ScriptCommentHelpInfoString = Get-ScriptCommentHelpInfoString -Description $Description
+        $ScriptCommentHelpInfoString = Get-ScriptCommentHelpInfoString -Description $Description -newscriptnfo
 
         $ScriptMetadataString = $PSScriptInfoString
         $ScriptMetadataString += "`r`n"
 
-        if("$requiresStrings".Trim())
-        {
+        if ("$requiresStrings".Trim()) {
             $ScriptMetadataString += "`r`n"
             $ScriptMetadataString += $requiresStrings -join "`r`n"
             $ScriptMetadataString += "`r`n"
@@ -225,30 +209,25 @@ function New-ScriptFileInfo
 
         $tempScriptFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random).ps1"
 
-        try
-        {
+        try {
             Microsoft.PowerShell.Management\Set-Content -Value $ScriptMetadataString -Path $tempScriptFilePath -Force -WhatIf:$false -Confirm:$false
 
             $scriptInfo = Test-ScriptFileInfo -Path $tempScriptFilePath
 
-            if(-not $scriptInfo)
-            {
+            if (-not $scriptInfo) {
                 # Above Test-ScriptFileInfo cmdlet writes the errors
                 return
             }
 
-    	    if($Path -and ($Force -or $PSCmdlet.ShouldProcess($Path, ($LocalizedData.NewScriptFileInfowhatIfMessage -f $Path) )))
-    	    {
+            if ($Path -and ($Force -or $PSCmdlet.ShouldProcess($Path, ($LocalizedData.NewScriptFileInfowhatIfMessage -f $Path) ))) {
                 Microsoft.PowerShell.Management\Copy-Item -Path $tempScriptFilePath -Destination $Path -Force -WhatIf:$false -Confirm:$false
             }
 
-            if($PassThru)
-            {
+            if ($PassThru) {
                 Write-Output -InputObject $ScriptMetadataString
             }
         }
-        finally
-        {
+        finally {
             Microsoft.PowerShell.Management\Remove-Item -Path $tempScriptFilePath -Force -WhatIf:$false -Confirm:$false -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         }
     }

--- a/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/New-ScriptFileInfo.ps1
@@ -188,23 +188,18 @@ function New-ScriptFileInfo {
             return
         }
 
-        $PSScriptInfoString = Get-PSScriptInfoString @params
-
         $requiresStrings = Get-RequiresString -RequiredModules $RequiredModules
+
+        $PSScriptInfoString = Get-PSScriptInfoString @params
 
         $ScriptCommentHelpInfoString = Get-ScriptCommentHelpInfoString -Description $Description -newscriptnfo
 
-        $ScriptMetadataString = $PSScriptInfoString
+        $ScriptMetadataString = $requiresStrings
         $ScriptMetadataString += "`r`n"
-
-        if ("$requiresStrings".Trim()) {
-            $ScriptMetadataString += "`r`n"
-            $ScriptMetadataString += $requiresStrings -join "`r`n"
-            $ScriptMetadataString += "`r`n"
-        }
-
+        $ScriptMetadataString += $PSScriptInfoString.TrimEnd('#>')
         $ScriptMetadataString += "`r`n"
         $ScriptMetadataString += $ScriptCommentHelpInfoString
+        $ScriptMetadataString += "`r`n"
         $ScriptMetadataString += "Param()`r`n`r`n"
 
         $tempScriptFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:TempPath -ChildPath "$(Get-Random).ps1"

--- a/src/PowerShellGet/public/psgetfunctions/Test-ScriptFileInfo.ps1
+++ b/src/PowerShellGet/public/psgetfunctions/Test-ScriptFileInfo.ps1
@@ -1,119 +1,121 @@
-function Test-ScriptFileInfo
-{
+function Test-ScriptFileInfo {
     <#
     .ExternalHelp PSModule-help.xml
     #>
-    [CmdletBinding(PositionalBinding=$false,
-                   DefaultParameterSetName='PathParameterSet',
-                   HelpUri='https://go.microsoft.com/fwlink/?LinkId=619791')]
+    [CmdletBinding(PositionalBinding = $false,
+        DefaultParameterSetName = 'PathParameterSet',
+        HelpUri = 'https://go.microsoft.com/fwlink/?LinkId=619791')]
     Param
     (
-        [Parameter(Mandatory=$true,
-                   Position=0,
-                   ValueFromPipelineByPropertyName=$true,
-                   ParameterSetName='PathParameterSet')]
+        [Parameter(Mandatory = $true,
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'PathParameterSet')]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
 
-        [Parameter(Mandatory=$true,
-                   ValueFromPipelineByPropertyName=$true,
-                   ParameterSetName='LiteralPathParameterSet')]
+        [Parameter(Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'LiteralPathParameterSet')]
         [ValidateNotNullOrEmpty()]
         [string]
         $LiteralPath
     )
 
-    Process
-    {
+    Process {
         $scriptFilePath = $null
-        if($Path)
-        {
+        if ($Path) {
             $scriptFilePath = Resolve-PathHelper -Path $Path -CallerPSCmdlet $PSCmdlet | Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore
 
-            if(-not $scriptFilePath -or -not (Microsoft.PowerShell.Management\Test-Path -Path $scriptFilePath -PathType Leaf))
-            {
+            if (-not $scriptFilePath -or -not (Microsoft.PowerShell.Management\Test-Path -Path $scriptFilePath -PathType Leaf)) {
                 $errorMessage = ($LocalizedData.PathNotFound -f $Path)
                 ThrowError  -ExceptionName "System.ArgumentException" `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId "PathNotFound" `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $Path `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId "PathNotFound" `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $Path `
+                    -ErrorCategory InvalidArgument
                 return
             }
         }
-        else
-        {
+        else {
             $scriptFilePath = Resolve-PathHelper -Path $LiteralPath -IsLiteralPath -CallerPSCmdlet $PSCmdlet | Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore
 
-            if(-not $scriptFilePath -or -not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $scriptFilePath -PathType Leaf))
-            {
+            if (-not $scriptFilePath -or -not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $scriptFilePath -PathType Leaf)) {
                 $errorMessage = ($LocalizedData.PathNotFound -f $LiteralPath)
                 ThrowError  -ExceptionName "System.ArgumentException" `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId "PathNotFound" `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $LiteralPath `
-                            -ErrorCategory InvalidArgument
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId "PathNotFound" `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $LiteralPath `
+                    -ErrorCategory InvalidArgument
                 return
             }
         }
 
-        if(-not $scriptFilePath.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase))
-        {
+        if (-not $scriptFilePath.EndsWith('.ps1', [System.StringComparison]::OrdinalIgnoreCase)) {
             $errorMessage = ($LocalizedData.InvalidScriptFilePath -f $scriptFilePath)
             ThrowError  -ExceptionName "System.ArgumentException" `
-                        -ExceptionMessage $errorMessage `
-                        -ErrorId "InvalidScriptFilePath" `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ExceptionObject $scriptFilePath `
-                        -ErrorCategory InvalidArgument
+                -ExceptionMessage $errorMessage `
+                -ErrorId "InvalidScriptFilePath" `
+                -CallerPSCmdlet $PSCmdlet `
+                -ExceptionObject $scriptFilePath `
+                -ErrorCategory InvalidArgument
             return
         }
 
+        Write-Host "start psscript"
         $PSScriptInfo = New-PSScriptInfoObject -Path $scriptFilePath
-
+        $psscriptinfo
+        Write-host "End scriptinfo"
         [System.Management.Automation.Language.Token[]]$tokens = $null;
         [System.Management.Automation.Language.ParseError[]]$errors = $null;
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptFilePath, ([ref]$tokens), ([ref]$errors))
 
 
         $notSupportedOnNanoErrorIds = @('WorkflowNotSupportedInPowerShellCore',
-                                        'ConfigurationNotSupportedInPowerShellCore')
+            'ConfigurationNotSupportedInPowerShellCore')
         $errorsAfterSkippingOneCoreErrors = $errors | Microsoft.PowerShell.Core\Where-Object { $notSupportedOnNanoErrorIds -notcontains $_.ErrorId}
 
-        if($errorsAfterSkippingOneCoreErrors)
-        {
+        if ($errorsAfterSkippingOneCoreErrors) {
             $errorMessage = ($LocalizedData.ScriptParseError -f $scriptFilePath)
             ThrowError  -ExceptionName "System.ArgumentException" `
-                        -ExceptionMessage $errorMessage `
-                        -ErrorId "ScriptParseError" `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ExceptionObject $errorsAfterSkippingOneCoreErrors `
-                        -ErrorCategory InvalidArgument
+                -ExceptionMessage $errorMessage `
+                -ErrorId "ScriptParseError" `
+                -CallerPSCmdlet $PSCmdlet `
+                -ExceptionObject $errorsAfterSkippingOneCoreErrors `
+                -ErrorCategory InvalidArgument
             return
         }
 
-        if($ast)
-        {
+        if ($ast) {
             # Get the block/group comment beginning with <#PSScriptInfo
             $CommentTokens = $tokens | Microsoft.PowerShell.Core\Where-Object {$_.Kind -eq 'Comment'}
 
             $psscriptInfoComments = $CommentTokens |
-                                        Microsoft.PowerShell.Core\Where-Object { $_.Extent.Text -match "<#PSScriptInfo" } |
-                                            Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore
+                Microsoft.PowerShell.Core\Where-Object { $_.Extent.Text -match "<#PSScriptInfo" } |
+                Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore
 
-            if(-not $psscriptInfoComments)
-            {
+            if (-not $psscriptInfoComments) {
                 $errorMessage = ($LocalizedData.MissingPSScriptInfo -f $scriptFilePath)
-                ThrowError  -ExceptionName "System.ArgumentException" `
-                            -ExceptionMessage $errorMessage `
-                            -ErrorId "MissingPSScriptInfo" `
-                            -CallerPSCmdlet $PSCmdlet `
-                            -ExceptionObject $scriptFilePath `
-                            -ErrorCategory InvalidArgument
+                ThrowError -ExceptionName "System.ArgumentException" `
+                    -ExceptionMessage $errorMessage `
+                    -ErrorId "MissingPSScriptInfo" `
+                    -CallerPSCmdlet $PSCmdlet `
+                    -ExceptionObject $scriptFilePath `
+                    -ErrorCategory InvalidArgument
                 return
+            }
+            If ($psscriptInfoComments.Text -notlike "*.DESCRIPTION*") {
+                $errorMessage = ($LocalizedData.MissingRequiredPSScriptInfoProperties -f $scriptFilePath)
+            ThrowError -ExceptionName "System.ArgumentException" `
+                -ExceptionMessage $errorMessage `
+                -ErrorId "MissingRequiredPSScriptInfoProperties" `
+                -CallerPSCmdlet $PSCmdlet `
+                -ExceptionObject $Path `
+                -ErrorCategory InvalidArgument
+            return
             }
 
             # $psscriptInfoComments.Text will have the multiline PSScriptInfo comment,
@@ -124,7 +126,7 @@ function Test-ScriptFileInfo
             $Value = ""
 
             # PSScriptInfo comment will be in following format:
-                <#PSScriptInfo
+            <#PSScriptInfo
 
                 .VERSION 1.0
 
@@ -163,68 +165,55 @@ function Test-ScriptFileInfo
             # First line is <#PSScriptInfo
             # Last line #>
             #
-            if($commentLines.Count -gt 2)
-            {
-                for($i = 1; $i -lt ($commentLines.count - 1); $i++)
-                {
+            if ($commentLines.Count -gt 2) {
+                for ($i = 1; $i -lt ($commentLines.count - 1); $i++) {
                     $line = $commentLines[$i]
 
-                    if(-not $line)
-                    {
+                    if (-not $line) {
                         continue
                     }
 
                     # A line is starting with . conveys a new metadata property
                     # __NEWLINE__ is used for replacing the value lines while adding the value to $PSScriptInfo object
                     #
-                    if($line.trim().StartsWith('.'))
-                    {
-                        $parts = $line.trim() -split '[.\s+]',3 | Microsoft.PowerShell.Core\Where-Object {$_}
+                    if ($line.trim().StartsWith('.')) {
+                        $parts = $line.trim() -split '[.\s+]', 3 | Microsoft.PowerShell.Core\Where-Object {$_}
 
-                        if($KeyName -and $Value)
-                        {
-                            if($keyName -eq $script:ReleaseNotes)
-                            {
+                        if ($KeyName -and $Value) {
+                            if ($keyName -eq $script:ReleaseNotes) {
                                 $Value = $Value.Trim() -split '__NEWLINE__'
                             }
-                            elseif($keyName -eq $script:DESCRIPTION)
-                            {
+                            elseif ($keyName -eq $script:DESCRIPTION) {
                                 $Value = $Value -split '__NEWLINE__'
                                 $Value = ($Value -join "`r`n").Trim()
                             }
-                            else
-                            {
+                            else {
                                 $Value = $Value -split '__NEWLINE__'  | Microsoft.PowerShell.Core\Where-Object { $_ }
 
-                                if($Value -and $Value.GetType().ToString() -eq "System.String")
-                                {
+                                if ($Value -and $Value.GetType().ToString() -eq "System.String") {
                                     $Value = $Value.Trim()
                                 }
                             }
 
                             ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                             -PropertyName $KeyName `
-                                                             -PropertyValue $Value `
-                                                             -CallerPSCmdlet $PSCmdlet
+                                -PropertyName $KeyName `
+                                -PropertyValue $Value `
+                                -CallerPSCmdlet $PSCmdlet
                         }
 
                         $KeyName = $null
                         $Value = ""
 
-                        if($parts.GetType().ToString() -eq "System.String")
-                        {
+                        if ($parts.GetType().ToString() -eq "System.String") {
                             $KeyName = $parts
                         }
-                        else
-                        {
+                        else {
                             $KeyName = $parts[0];
                             $Value = $parts[1]
                         }
                     }
-                    else
-                    {
-                        if($Value)
-                        {
+                    else {
+                        if ($Value) {
                             # __NEWLINE__ is used for replacing the value lines while adding the value to $PSScriptInfo object
                             $Value += '__NEWLINE__'
                         }
@@ -233,31 +222,26 @@ function Test-ScriptFileInfo
                     }
                 }
 
-                if($KeyName -and $Value)
-                {
-                    if($keyName -eq $script:ReleaseNotes)
-                    {
+                if ($KeyName -and $Value) {
+                    if ($keyName -eq $script:ReleaseNotes) {
                         $Value = $Value.Trim() -split '__NEWLINE__'
                     }
-                    elseif($keyName -eq $script:DESCRIPTION)
-                    {
+                    elseif ($keyName -eq $script:DESCRIPTION) {
                         $Value = $Value -split '__NEWLINE__'
                         $Value = ($Value -join "`r`n").Trim()
                     }
-                    else
-                    {
+                    else {
                         $Value = $Value -split '__NEWLINE__'  | Microsoft.PowerShell.Core\Where-Object { $_ }
 
-                        if($Value -and $Value.GetType().ToString() -eq "System.String")
-                        {
+                        if ($Value -and $Value.GetType().ToString() -eq "System.String") {
                             $Value = $Value.Trim()
                         }
                     }
 
                     ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                     -PropertyName $KeyName `
-                                                     -PropertyValue $Value `
-                                                     -CallerPSCmdlet $PSCmdlet
+                        -PropertyName $KeyName `
+                        -PropertyValue $Value `
+                        -CallerPSCmdlet $PSCmdlet
 
                     $KeyName = $null
                     $Value = ""
@@ -265,71 +249,65 @@ function Test-ScriptFileInfo
             }
 
             $helpContent = $ast.GetHelpContent()
-            if($helpContent -and $helpContent.Description)
-            {
+            if ($helpContent -and $helpContent.Description) {
                 ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                 -PropertyName $script:DESCRIPTION `
-                                                 -PropertyValue $helpContent.Description.Trim() `
-                                                 -CallerPSCmdlet $PSCmdlet
+                    -PropertyName $script:DESCRIPTION `
+                    -PropertyValue $helpContent.Description.Trim() `
+                    -CallerPSCmdlet $PSCmdlet
 
             }
 
             # Handle RequiredModules
-            if((Microsoft.PowerShell.Utility\Get-Member -InputObject $ast -Name 'ScriptRequirements') -and
-               $ast.ScriptRequirements -and
-               (Microsoft.PowerShell.Utility\Get-Member -InputObject $ast.ScriptRequirements -Name 'RequiredModules') -and
-               $ast.ScriptRequirements.RequiredModules)
-            {
+            if ((Microsoft.PowerShell.Utility\Get-Member -InputObject $ast -Name 'ScriptRequirements') -and
+                $ast.ScriptRequirements -and
+                (Microsoft.PowerShell.Utility\Get-Member -InputObject $ast.ScriptRequirements -Name 'RequiredModules') -and
+                $ast.ScriptRequirements.RequiredModules) {
                 ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                 -PropertyName $script:RequiredModules `
-                                                 -PropertyValue $ast.ScriptRequirements.RequiredModules `
-                                                 -CallerPSCmdlet $PSCmdlet
+                    -PropertyName $script:RequiredModules `
+                    -PropertyValue $ast.ScriptRequirements.RequiredModules `
+                    -CallerPSCmdlet $PSCmdlet
             }
 
             # Get all defined functions and populate DefinedCommands, DefinedFunctions and DefinedWorkflows
-            $allCommands = $ast.FindAll({param($i) return ($i.GetType().Name -eq 'FunctionDefinitionAst')}, $true)
+            $allCommands = $ast.FindAll( {param($i) return ($i.GetType().Name -eq 'FunctionDefinitionAst')}, $true)
 
-            if($allCommands)
-            {
+            if ($allCommands) {
                 $allCommandNames = $allCommands | ForEach-Object {$_.Name} | Select-Object -Unique -ErrorAction Ignore
                 ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                 -PropertyName $script:DefinedCommands `
-                                                 -PropertyValue $allCommandNames `
-                                                 -CallerPSCmdlet $PSCmdlet
+                    -PropertyName $script:DefinedCommands `
+                    -PropertyValue $allCommandNames `
+                    -CallerPSCmdlet $PSCmdlet
 
                 $allFunctionNames = $allCommands | Where-Object {-not $_.IsWorkflow}  | ForEach-Object {$_.Name} | Select-Object -Unique -ErrorAction Ignore
                 ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                 -PropertyName $script:DefinedFunctions `
-                                                 -PropertyValue $allFunctionNames `
-                                                 -CallerPSCmdlet $PSCmdlet
+                    -PropertyName $script:DefinedFunctions `
+                    -PropertyValue $allFunctionNames `
+                    -CallerPSCmdlet $PSCmdlet
 
 
                 $allWorkflowNames = $allCommands | Where-Object {$_.IsWorkflow} | ForEach-Object {$_.Name} | Select-Object -Unique -ErrorAction Ignore
                 ValidateAndAdd-PSScriptInfoEntry -PSScriptInfo $PSScriptInfo `
-                                                 -PropertyName $script:DefinedWorkflows `
-                                                 -PropertyValue $allWorkflowNames `
-                                                 -CallerPSCmdlet $PSCmdlet
+                    -PropertyName $script:DefinedWorkflows `
+                    -PropertyValue $allWorkflowNames `
+                    -CallerPSCmdlet $PSCmdlet
             }
         }
 
         # Ensure that the script file has the required metadata properties.
-        if(-not $PSScriptInfo.Version -or -not $PSScriptInfo.Guid -or -not $PSScriptInfo.Author -or -not $PSScriptInfo.Description)
-        {
+        if (((-not $PSScriptInfo.Version) -or ($PSScriptInfo.Version -like "")) -or ((-not $PSScriptInfo.Guid) -or ($PSScriptInfo.Guid -like "")) -or ((-not $PSScriptInfo.Author) -or ($PSScriptInfo.Author -like "")) -or ((-not $PSScriptInfo.Description) -or ($PSScriptInfo.Description -like ""))) {
             $errorMessage = ($LocalizedData.MissingRequiredPSScriptInfoProperties -f $scriptFilePath)
-            ThrowError  -ExceptionName "System.ArgumentException" `
-                        -ExceptionMessage $errorMessage `
-                        -ErrorId "MissingRequiredPSScriptInfoProperties" `
-                        -CallerPSCmdlet $PSCmdlet `
-                        -ExceptionObject $Path `
-                        -ErrorCategory InvalidArgument
+            ThrowError -ExceptionName "System.ArgumentException" `
+                -ExceptionMessage $errorMessage `
+                -ErrorId "MissingRequiredPSScriptInfoProperties" `
+                -CallerPSCmdlet $PSCmdlet `
+                -ExceptionObject $Path `
+                -ErrorCategory InvalidArgument
             return
         }
 
-        if ($PSScriptInfo.Version -match '-')
-        {
+        if ($PSScriptInfo.Version -match '-') {
             $result = ValidateAndGet-VersionPrereleaseStrings -Version $PSScriptInfo.Version  -CallerPSCmdlet $PSCmdlet
-            if (-not $result)
-            {
+            if (-not $result) {
                 # ValidateAndGet-VersionPrereleaseStrings throws the error.
                 # returning to avoid further execution when different values are specified for -ErrorAction parameter
                 return

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -5,6 +5,7 @@ echo "TRAVIS_EVENT_TYPE value $TRAVIS_EVENT_TYPE"
 
 if [ $TRAVIS_EVENT_TYPE = cron ] || [ $TRAVIS_EVENT_TYPE = api ]; then
     sudo pwsh -c "Import-Module ./tools/build.psm1;
+                  Install-PackageManagement;
                   Install-Dependencies;
                   Update-ModuleManifestFunctions;
                   Publish-ModuleArtifacts;
@@ -12,6 +13,7 @@ if [ $TRAVIS_EVENT_TYPE = cron ] || [ $TRAVIS_EVENT_TYPE = api ]; then
                   Invoke-PowerShellGetTest -IsFullTestPass;"
 else
     sudo pwsh -c "Import-Module ./tools/build.psm1;
+                  Install-PackageManagement;
                   Install-Dependencies;
                   Update-ModuleManifestFunctions;
                   Publish-ModuleArtifacts;


### PR DESCRIPTION
This pull request fixes the new-scriptfileinfo command in the powershellget powershell module.  Currently, when the aforementioned command is run, the file it generates contains invalid syntax that causes the "Test-scriptfileinfo" command to fail when the generated file is passed to it as a parameter:
![image](https://user-images.githubusercontent.com/11139575/50126037-42494400-0239-11e9-8ea4-db569b8ecb58.png)

However, the changes I have made generate script file info which can be published to the psgallery:
![image](https://user-images.githubusercontent.com/11139575/50165269-96dcd580-02b2-11e9-8826-b366451ee702.png)

It is important to note that "test-scriptfileinfo" does not correctly parse files generated by "new-scriptfileinfo", as files generated with "new-scriptfileinfo" are successfully passed to "test-scriptfileinfo", but fail to publish with error.
![image](https://user-images.githubusercontent.com/11139575/50167095-6139eb80-02b6-11e9-88f2-4bdb03c6c5a1.png)
