### PR TITLE
Emit warning for deprecation of Find-RoleCapability

### DIFF
--- a/Test/FindPSResource.Tests.ps1
+++ b/Test/FindPSResource.Tests.ps1
@@ -190,6 +190,12 @@ Describe 'Test CompatPowerShellGet: Find-PSResource' -tags 'CI' {
         $resModuleType = Out-String -InputObject $resModule.Type
         $resModuleType.Replace(",", " ").Split() | Should -Contain "Module"
     }
+
+    It "Find-RoleCapability should emit warning" {
+        $results = Find-RoleCapability -Name $testModuleName -Repository $PSGalleryName -WarningVariable wv
+        $results | Should -BeNullOrEmpty
+        $wv[0] | Should -Be "The cmdlet 'Find-RoleCapability' is deprecated."
+    }
 }
 
 # Ensure that PSGet v2 was not loaded during the test via command discovery

--- a/src/CompatPowerShellGet.psm1
+++ b/src/CompatPowerShellGet.psm1
@@ -573,6 +573,7 @@ param(
     begin
     {
         # Find-RoleCability is no longer supported
+        Write-Warning -Message "The cmdlet 'Find-RoleCapability' is deprecated."
     }
     <#
     .ForwardHelpTargetName Find-RoleCapability


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Find-RoleCapability`, which is a no-op, now emits a warning informing users the cmdlet is no longer supported.

## PR Context
Resolves #30 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
