### PR TITLE
Add Force parameters to proxies for Update-* cmdlets

### DIFF
--- a/Test/UpdatePSResource.Tests.ps1
+++ b/Test/UpdatePSResource.Tests.ps1
@@ -347,6 +347,24 @@ Describe 'Test CompatPowerShellGet: Update-PSResource' -tags 'CI' {
         $res.Name | Should -Contain $testModuleName
         $res.Version | Should -Contain "3.0.0.0"
     }
+
+    It "Update resource installed given -Name and -Force parameters" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
+
+        Update-Module -Name $testModuleName -RequiredVersion "3.0.0.0" -Foce
+        $res = Get-InstalledPSResource -Name $testModuleName
+
+        $isPkgUpdated = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -gt [System.Version]"1.0.0.0")
+            {
+                $isPkgUpdated = $true
+            }
+        }
+
+        $isPkgUpdated | Should -Be $true
+    }
 }
 
 # Ensure that PSGet v2 was not loaded during the test via command discovery

--- a/src/CompatPowerShellGet.psm1
+++ b/src/CompatPowerShellGet.psm1
@@ -2409,7 +2409,6 @@ param(
             # Parameter Deletions (unsupported in v3)
             if ( $PSBoundParameters['Proxy'] )              { $null = $PSBoundParameters.Remove('Proxy') }
             if ( $PSBoundParameters['ProxyCredential'] )    { $null = $PSBoundParameters.Remove('ProxyCredential') }
-            if ( $PSBoundParameters['Force'] )              { $null = $PSBoundParameters.Remove('Force') }
             # END PARAMETER MAP
 
             $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Update-PSResource', [System.Management.Automation.CommandTypes]::Cmdlet)
@@ -2513,7 +2512,6 @@ param(
             # Parameter Deletions (unsupported in v3)
             if ( $PSBoundParameters['Proxy'] )              { $null = $PSBoundParameters.Remove('Proxy') }
             if ( $PSBoundParameters['ProxyCredential'] )    { $null = $PSBoundParameters.Remove('ProxyCredential') }
-            if ( $PSBoundParameters['Force'] )              { $null = $PSBoundParameters.Remove('Force') }
             # END PARAMETER MAP
 
             $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Update-PSResource', [System.Management.Automation.CommandTypes]::Cmdlet)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Force` parameters were being incorrectly removed from `Update-Module` and `Update-Script` proxies.  This PR allows for `Force` param to be passed through to `Update-PSResource`.

## PR Context

Resolves #28 
